### PR TITLE
WordPress 6.2 Compatibility For Fullwidth Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** full width, fullwidth, template, beaver builder, elementor, genesis, primer, full width template, remove sidebar, page builder  
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Requires at least:** 4.2  
-**Tested up to:** 6.1  
+**Tested up to:** 6.2  
 **Stable tag:** 1.1.1  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce, WPCrafter, ramiy
 Tags: full width, fullwidth, template, beaver builder, elementor, genesis, primer, full width template, remove sidebar, page builder
 Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.2
-Tested up to: 6.1
+Tested up to: 6.2
 Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Summary
- Provided WordPress 6.2 Compatibility.

Changes Made
- Updated Readme "Tested Upto" version to 6.2

Testing
- Tested with the default Twenty Twenty One WordPress Theme which does not offer FW Layout.
- Checked by setting FW Fullwidth Option on Wordpress old setup v6.1.1 and Fullwidth templates v1.1.1 then checking the same settings if applying correctly on Wordpress 6.2.
- Checked all three FW options offered by the plugin.