### PR TITLE
Resolved textdomain load early warnings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Requires at least:** 4.2  
 **Tested up to:** 6.8  
-**Stable tag:** 1.1.1  
+**Stable tag:** 1.1.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -87,6 +87,9 @@ Check Screenshots for more details.
 5. Blank - No Header / Footer Template
 
 ## Changelog ##
+
+### 1.1.2 ###
+- Fix: Fixed PHP notice by delaying text domain loading for Fullwidth Template plugin until the init action.
 
 ### 1.1.1 ###
 - Fix: Fixed compatibility with other plugins with respect to the admin notice.

--- a/fullwidth-page-template.php
+++ b/fullwidth-page-template.php
@@ -7,34 +7,33 @@
  * Author URI:      https://www.brainstormforce.com
  * Text Domain:     fullwidth-templates
  * Domain Path:     /languages
- * Version:         1.1.1
+ * Version:         1.1.2
  *
  * @package         Fullwidth_Page_Templates
  */
 
-// Exit if accessed directly
+// Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 require_once 'class-fullwidth-page-templates.php';
 
-define( 'FPT_VER', '1.1.1' );
+define( 'FPT_VER', '1.1.2' );
 define( 'FPT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FPT_URL', plugins_url( '/', __FILE__ ) );
 define( 'FPT_PATH', plugin_basename( __FILE__ ) );
 
 /**
- * Load the Plugin Class.
+ * Load the Plugin Class and translations.
  */
 function init_fullwidth_template() {
+    // Load localization file.
+    load_plugin_textdomain( 'fullwidth-templates', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 
-	// Load localization file
-	load_plugin_textdomain( 'fullwidth-templates' );
-
-	// Init dynamic header footer
-	new Fullwidth_Page_Templates();
-
+    // Init dynamic header footer.
+    new Fullwidth_Page_Templates();
 }
 
-add_action( 'plugins_loaded', 'init_fullwidth_template' );
+// Load everything on init instead of plugins_loaded.
+add_action( 'init', 'init_fullwidth_template' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-header-footer",
-  "version": "0.1.0",
+  "version": "1.1.2",
   "main": "Gruntfile.js",
   "author": "YOUR NAME HERE",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: full width, fullwidth, template, beaver builder, elementor, genesis, prime
 Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.2
 Tested up to: 6.8
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -87,6 +87,9 @@ Check Screenshots for more details.
 5. Blank - No Header / Footer Template
 
 == Changelog ==
+
+= 1.1.2 =
+- Fix: Fixed PHP notice by delaying text domain loading for Fullwidth Template plugin until the init action.
 
 = 1.1.1 =
 - Fix: Fixed compatibility with other plugins with respect to the admin notice.


### PR DESCRIPTION
- Resolved textdomain load early warnings.
- Error - `PHP Notice: Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>fullwidth-templates</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. `