### PR TITLE
WordPress 7.1 Compatibility

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml.yml
+++ b/.github/workflows/push-asset-readme-update.yml.yml
@@ -7,6 +7,7 @@ jobs:
   master:
     name: Push to master
     runs-on: ubuntu-latest
+    environment: production
     steps:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update

--- a/.github/workflows/push-asset-readme-update.yml.yml
+++ b/.github/workflows/push-asset-readme-update.yml.yml
@@ -15,3 +15,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        IGNORE_OTHER_FILES: true

--- a/.github/workflows/push-to-deploy.yml
+++ b/.github/workflows/push-to-deploy.yml
@@ -9,10 +9,20 @@ jobs:
   deploy:
     name: Deploy to WordPress.org
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Verify release tag is reachable from master
+        run: |
+          git fetch --no-tags --depth=50 origin master:refs/remotes/origin/master
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/master; then
+            echo "::error::Tag $GITHUB_REF_NAME ($GITHUB_SHA) is not reachable from master. Refusing to deploy."
+            exit 1
+          fi
 
       # Optional: Add build steps if needed (uncomment if your plugin needs it)
       # - name: Install dependencies and build assets

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** full width, fullwidth, template, beaver builder, elementor, genesis, primer, full width template, remove sidebar, page builder  
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Requires at least:** 4.2  
-**Tested up to:** 6.9  
+**Tested up to:** 7.0  
 **Stable tag:** 1.2.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** full width, fullwidth, template, beaver builder, elementor, genesis, primer, full width template, remove sidebar, page builder  
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Requires at least:** 4.2  
-**Tested up to:** 7.0  
+**Tested up to:** 7.1  
 **Stable tag:** 1.2.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce, WPCrafter, ramiy
 Tags: full width, fullwidth, template, beaver builder, elementor, genesis, primer, full width template, remove sidebar, page builder
 Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.2
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce, WPCrafter, ramiy
 Tags: full width, fullwidth, template, beaver builder, elementor, genesis, primer, full width template, remove sidebar, page builder
 Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.2
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## WordPress 7.1 Compatibility
- Tested with WordPress 7.1 and it's working fine (bumped `Tested up to` in `README.md` and `readme.txt`).

## Deploy workflow hardening (ports [astra-sites#886](https://github.com/brainstormforce/astra-sites/pull/886))
- Added `environment: production` to the deploy jobs so org-level `SVN_*` secrets are only reachable from workflows running on `master` + tags (via a scoped `production` GitHub Environment restricted to those refs).
- Added a guard in `push-to-deploy.yml` that refuses to deploy a tag not reachable from `master`.

## Release tracking
Closes brainstormforce/astra#8031 (WordPress 7.1 compatibility release epic)

